### PR TITLE
Create a module to generate self-signed TLS certs

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Gruntwork, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,157 @@
+# Private TLS Cert
+
+This repository contains a [Terraform](https://www.terraform.io/) module that can be used to generate self-signed TLS
+certificate. To be more accurate, the module generates the following:
+
+* A Certificate Authority (CA) public key 
+* The public and private keys of a TLS certificate signed by the CA
+
+This TLS certificate is meant to be used with **private** services, such as a web service used only within your 
+company. For publicly-accessible services, especially services you access through a web browser, you should NOT use 
+this module, and instead get certificates from a commercial Certificate Authority, such as 
+[Let's Encrypt](https://letsencrypt.org/).
+
+If you're unfamiliar with how TLS certificates work, check out the [Background section](#background).
+
+
+
+
+## Quick start
+
+*Note: This Terraform module uses bash commands in a `local-exec` provisioner to copy the generate certificates to
+files, so currently, it will only work on Linux, Unix, and OS X.*
+
+1. `git clone` this repo to your computer and go into the `modules/generate-cert` folder.
+
+1. Open `vars.tf` and fill in the variables that do not have a default.
+
+1. DO NOT configure Terraform remote state storage for this code. You do NOT want to store the state files as they 
+   will contain the private keys for the certificates.
+
+1. Run `terraform apply`. The output will show you the paths to the generated files:
+
+    ```
+    Outputs:
+    
+    ca_public_key_file_path = ca.key.pem
+    private_key_file_path = my-app.key.pem
+    public_key_file_path = my-app.crt.pem
+    ```
+    
+1. Delete your local Terraform state:
+
+    ```
+    rm -rf terraform.tfstate*
+    ```
+
+   The Terraform state will contain the private keys for the certificates, so it's important to clean it up!
+
+You can now use the TLS certs with your applications! To inspect a certificate, you can use OpenSSL:
+
+```
+openssl x509 -inform pem -noout -text -in my-app.crt.pem
+```
+
+
+
+
+## Background
+
+
+### How TLS/SSL Works
+
+The industry-standard way to add encryption for data in motion is to use TLS (the successor to SSL). There are many 
+examples online explaining how TLS works, but here are the basics:
+
+- Some entity decides to be a "Certificate Authority" ("CA") meaning it will issue TLS certificates to websites or 
+  other services
+
+- An entity becomes a Certificate Authority by creating a public/private key pair and publishing the public portion 
+  (typically known as the "CA Cert"). The private key is kept under the tightest possible security since anyone who 
+  possesses it could issue TLS certificates as if they were this Certificate Authority!
+
+- In fact, the consequences of a CA's private key being compromised are so disastrous that CA's typically create an 
+  "intermediate" CA keypair with their "root" CA key, and only issue TLS certificates with the intermediate key.
+
+- Your client (e.g. a web browser) can decide to trust this newly created Certificate Authority by including its CA 
+  Cert (the CA's public key) when making an outbound request to a service that uses the TLS certificate.
+
+- When CAs issue a TLS certificate ("TLS cert") to a service, they again create a public/private keypair, but this time 
+  the public key is "signed" by the CA. That public key is what you view when you click on the lock icon in a web 
+  browser and what a service "advertises" to any clients such as web browsers to declare who it is. When we say that 
+  the CA signed a public key, we mean that, cryptographically, any possessor of the CA Cert can validate that this same 
+  CA issued this particular public key.
+
+- The public key is more generally known as the TLS cert.
+
+- The private key created by the CA must be kept secret by the service since the possessor of the private key can 
+  "prove" they are whoever the TLS cert (public key) claims to be as part of the TLS protocol.
+
+- How does that "proof" work? Well, your web browser will attempt to validate the TLS cert in two ways:
+  - First, it will ensure this public key (TLS cert) is in fact signed by a CA it trusts.
+  - Second, using the TLS protocol, your browser will encrypt a message with the public key (TLS cert) that only the
+    possessor of the corresponding private key can decrypt. In this manner, your browser will be able to come up with a
+    symmetric encryption key it can use to encrypt all traffic for just that one web session.
+
+- Now your client/browser has:
+  - declared which CA it will trust
+  - verified that the service it's connecting to possesses a certificate issued by a CA it trusts
+  - used that service's public key (TLS cert) to establish a secure session
+
+
+### Commercial or Public Certificate Authorities
+
+For public services like banks, healthcare, and the like, it makes sense to use a "Commercial CA" like Verisign, Thawte,
+or Digicert, or better yet a widely trusted but free service like [Let's Encrypt](https://letsencrypt.org/). That's 
+because every web browser comes pre-configured with a set of CA's that it trusts. This means the client connecting to 
+the bank doesn't have to know anything about CA's at all. Instead, their web browser is configured to trust the CA that 
+happened to issue the bank's certificate.
+
+Connecting securely to private services is similar to connecting to your bank's website over TLS, with one primary 
+difference: **We want total control over the CA.**
+
+Imagine if we used a commercial CA to issue our private TLS certificate and that commercial or public CA--which we 
+don't control--were compromised. Now the attackers of that commercial or public CA could impersonate our private server. 
+And indeed, [it](https://www.theguardian.com/technology/2011/sep/05/diginotar-certificate-hack-cyberwar) [has](
+https://www.schneier.com/blog/archives/2012/02/verisign_hacked.html) [happened](
+http://www.infoworld.com/article/2623707/hacking/the-real-security-issue-behind-the-comodo-hack.html)
+multiple times.
+
+
+### How We'll Generate a TLS Cert for Private Services
+
+One option is to be very selective about choosing a commercial CA, but to what benefit? What we want instead is 
+assurance that our private service really was launched by people we trust. Those same people--let's call them our 
+"operators"--can become their *own* CA and generate their *own* TLS certificate for the private service.
+
+Sure, no one else in the world will trust this CA, but we don't care because we only need our organization to trust 
+this CA.
+
+So here's our strategy for issuing a TLS Cert for a private service:
+
+1. **Create our own CA.**
+  - If a client wishes to trust our CA, they need only reference this CA public key.
+  - We'll deal with the private key in a moment.
+
+1. **Using our CA, issue a TLS Certificate for our private service.**
+  - Create a public/private key pair for the private service, and have the CA sign the public key.
+  - This means anyone who trusts the CA will trust that the possessor of the private key that corresponds to this public 
+    key is who they claim to be.
+  - We will be extremely careful with the TLS private key since anyone who obtains it can impersonate our private 
+    service! For this reason, we recommend immediately encrypting the private key with 
+    [KMS](https://aws.amazon.com/kms/).
+
+1. **Freely advertise our CA's public key to all internal services.**
+  - Any service that wishes to connect securely to our private service will need our CA's public key so it can declare 
+    that it trusts this CA, and thereby the TLS cert it issued to the private service.
+
+1. **Throw away the CA private key.**
+    - By erasing a CA private key it's impossible for the CA to be compromised, because there's no private key to steal!
+    - Future certs can be generated with a new CA.
+
+
+
+
+## License
+
+This code is released under the MIT License. See [LICENSE.txt](/LICENSE.txt).

--- a/modules/generate-cert/main.tf
+++ b/modules/generate-cert/main.tf
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------------------------------------------------
+#  CREATE A CA CERTIFICATE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "tls_private_key" "ca" {
+  algorithm   = "${var.private_key_algorithm}"
+  ecdsa_curve = "${var.private_key_ecdsa_curve}"
+  rsa_bits    = "${var.private_key_rsa_bits}"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm     = "${tls_private_key.ca.algorithm}"
+  private_key_pem   = "${tls_private_key.ca.private_key_pem}"
+  is_ca_certificate = true
+
+  validity_period_hours = "${var.validity_period_hours}"
+  allowed_uses          = ["${var.ca_allowed_uses}"]
+
+  subject {
+    common_name  = "${var.ca_common_name}"
+    organization = "${var.organization_name}"
+  }
+
+  # Store the CA public key in a file.
+  provisioner "local-exec" {
+    command = "echo '${tls_self_signed_cert.ca.cert_pem}' > '${var.ca_public_key_file_path}' && chmod ${var.permissions} '${var.ca_public_key_file_path}' && chown ${var.owner} '${var.ca_public_key_file_path}'"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A TLS CERTIFICATE SIGNED USING THE CA CERTIFICATE
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "tls_private_key" "cert" {
+  algorithm   = "${var.private_key_algorithm}"
+  ecdsa_curve = "${var.private_key_ecdsa_curve}"
+  rsa_bits    = "${var.private_key_rsa_bits}"
+
+  # Store the certificate's private key in a file.
+  provisioner "local-exec" {
+    command = "echo '${tls_private_key.cert.private_key_pem}' > '${var.private_key_file_path}' && chmod ${var.permissions} '${var.private_key_file_path}' && chown ${var.owner} '${var.private_key_file_path}'"
+  }
+}
+
+resource "tls_cert_request" "cert" {
+  key_algorithm   = "${tls_private_key.cert.algorithm}"
+  private_key_pem = "${tls_private_key.cert.private_key_pem}"
+
+  dns_names    = ["${var.dns_names}"]
+  ip_addresses = ["${var.ip_addresses}"]
+
+  subject {
+    common_name  = "${var.common_name}"
+    organization = "${var.organization_name}"
+  }
+}
+
+resource "tls_locally_signed_cert" "cert" {
+  cert_request_pem = "${tls_cert_request.cert.cert_request_pem}"
+
+  ca_key_algorithm   = "${tls_private_key.ca.algorithm}"
+  ca_private_key_pem = "${tls_private_key.ca.private_key_pem}"
+  ca_cert_pem        = "${tls_self_signed_cert.ca.cert_pem}"
+
+  validity_period_hours = "${var.validity_period_hours}"
+  allowed_uses          = ["${var.allowed_uses}"]
+
+  # Store the certificate's public key in a file.
+  provisioner "local-exec" {
+    command = "echo '${tls_locally_signed_cert.cert.cert_pem}' > '${var.public_key_file_path}' && chmod ${var.permissions} '${var.public_key_file_path}' && chown ${var.owner} '${var.public_key_file_path}'"
+  }
+}

--- a/modules/generate-cert/outputs.tf
+++ b/modules/generate-cert/outputs.tf
@@ -1,0 +1,12 @@
+output "ca_public_key_file_path" {
+  value = "${var.ca_public_key_file_path}"
+}
+
+output "public_key_file_path" {
+  value = "${var.public_key_file_path}"
+}
+
+output "private_key_file_path" {
+  value = "${var.private_key_file_path}"
+}
+

--- a/modules/generate-cert/vars.tf
+++ b/modules/generate-cert/vars.tf
@@ -1,0 +1,92 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ca_public_key_file_path" {
+  description = "Write the PEM-encoded CA certificate public key to this path (e.g. /etc/tls/ca.crt.pem)."
+}
+
+variable "public_key_file_path" {
+  description = "Write the PEM-encoded certificate public key to this path (e.g. /etc/tls/my-app.crt.pem)."
+}
+
+variable "private_key_file_path" {
+  description = "Write the PEM-encoded certificate private key to this path (e.g. /etc/tls/my-app.key.pem)."
+}
+
+variable "owner" {
+  description = "The OS user who should be given ownership over the certificate files."
+}
+
+variable "organization_name" {
+  description = "The name of the organization to associate with the certificates (e.g. Acme Co)."
+}
+
+variable "ca_common_name" {
+  description = "The common name to use in the subject of the CA certificate (e.g. acme.co cert)."
+}
+
+variable "common_name" {
+  description = "The common name to use in the subject of the certificate (e.g. acme.co cert)."
+}
+
+variable "dns_names" {
+  description = "List of DNS names for which the certificate will be valid (e.g. foo.example.com)."
+  type        = "list"
+}
+
+variable "ip_addresses" {
+  description = "List of IP addresses for which the certificate will be valid (e.g. 127.0.0.1)."
+  type        = "list"
+}
+
+variable "validity_period_hours" {
+  description = "The number of hours after initial issuing that the certificate will become invalid."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ca_allowed_uses" {
+  description = "List of keywords from RFC5280 describing a use that is permitted for the CA certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
+  type        = "list"
+
+  default = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature",
+  ]
+}
+
+variable "allowed_uses" {
+  description = "List of keywords from RFC5280 describing a use that is permitted for the issued certificate. For more info and the list of keywords, see https://www.terraform.io/docs/providers/tls/r/self_signed_cert.html#allowed_uses."
+  type        = "list"
+
+  default = [
+    "key_encipherment",
+    "digital_signature",
+  ]
+}
+
+variable "permissions" {
+  description = "The Unix file permission to assign to the cert files (e.g. 0600)."
+  default     = "0600"
+}
+
+variable "private_key_algorithm" {
+  description = "The name of the algorithm to use for private keys. Must be one of: RSA or ECDSA."
+  default     = "RSA"
+}
+
+variable "private_key_ecdsa_curve" {
+  description = "The name of the elliptic curve to use. Should only be used if var.private_key_algorithm is ECDSA. Must be one of P224, P256, P384 or P521."
+  default     = "P256"
+}
+
+variable "private_key_rsa_bits" {
+  description = "The size of the generated RSA key in bits. Should only be used if var.private_key_algorithm is RSA."
+  default     = "2048"
+}


### PR DESCRIPTION
This is the first version of this module. It lets you create a self-signed TLS cert with a call to `terraform apply`. I find this a lot easier to get right than running the `openssl` tool. We had this code in a private repo, but I want to be able to use it in multiple places, so I figured we could open source this small piece.